### PR TITLE
refactor: remove pots state and related fetch logic from UserContext

### DIFF
--- a/src/app/context/UserContext.tsx
+++ b/src/app/context/UserContext.tsx
@@ -7,11 +7,10 @@ import React, {
   // SetStateAction,
   useEffect,
 } from "react";
-import { Transaction, Pot } from "@prisma/client";
+import { Transaction } from "@prisma/client";
 
 type UserContextType = {
   transactions: Transaction[];
-  pots: Pot[];
 };
 
 type Props = {
@@ -30,35 +29,34 @@ export const useUser = () => {
 
 export const UserProvider = ({ children }: Props) => {
   const [transactions, setTransactions] = useState<Transaction[]>([]);
-  const [pots, setPots] = useState<Pot[]>([]);
+  // const [pots, setPots] = useState<Pot[]>([]);
 
   useEffect(() => {
-    // async function fetchTransactions() {
-    //   try {
-    //     const response = await fetch("/api/transactions");
-    //     const data = await response.json();
-    //     setTransactions(data);
-    //   } catch (error) {
-    //     console.log(error);
-    //   }
-    // }
-    // fetchTransactions();
-    async function fetchPots() {
+    async function fetchTransactions() {
       try {
-        const response = await fetch("/api/pots");
+        const response = await fetch("/api/transactions");
         const data = await response.json();
-        setPots(data);
-        console.log(data);
+        setTransactions(data);
       } catch (error) {
         console.log(error);
       }
     }
-    fetchPots();
+    fetchTransactions();
+    // async function fetchPots() {
+    //   try {
+    //     const response = await fetch("/api/pots");
+    //     const data = await response.json();
+    //     setPots(data);
+    //     console.log(data);
+    //   } catch (error) {
+    //     console.log(error);
+    //   }
+    // }
+    // fetchPots();
   }, []);
 
   const data = {
     transactions,
-    pots,
   };
 
   return <UserContext.Provider value={data}>{children}</UserContext.Provider>;


### PR DESCRIPTION
This pull request includes changes to the `src/app/context/UserContext.tsx` file to remove the `Pot` type and its associated state management, focusing solely on `Transaction` type and related operations.

Key changes include:

* Removed the `Pot` type from the `UserContextType` definition and associated state management.
* Updated the `UserProvider` component to remove the `pots` state and its related fetching logic, ensuring only `transactions` are managed and fetched.